### PR TITLE
Check size compatibility in fermionic_kron and partial_trace

### DIFF
--- a/src/tensor_product.jl
+++ b/src/tensor_product.jl
@@ -59,14 +59,14 @@ function check_tensor_product_basis_compatibility(b1::AbstractHilbertSpace, b2::
     end
 end
 
-size_compatibility(m::AbstractMatrix, H) = size(m) == size(H)
-size_compatibility(m::UniformScaling, H) = true
-size_compatibility(m::AbstractVector, H) = length(m) == size(H, 1)
-kron_sizes_compatibility(ms, Hs) = all(size_compatibility(m, H) for (m, H) in zip(ms, Hs))
+size_compatible(m::AbstractMatrix, H) = size(m) == size(H)
+size_compatible(m::UniformScaling, H) = true
+size_compatible(m::AbstractVector, H) = length(m) == size(H, 1)
+kron_sizes_compatible(ms, Hs) = all(size_compatible(m, H) for (m, H) in zip(ms, Hs))
 
-@testitem "Size compatibility" begin
+@testitem "Size compatible" begin
     using LinearAlgebra, Random
-    import FermionicHilbertSpaces: kron_sizes_compatibility
+    import FermionicHilbertSpaces: kron_sizes_compatible
     Random.seed!(1234)
     H1 = hilbert_space(1:2)
     H2 = hilbert_space(3:3)
@@ -74,12 +74,12 @@ kron_sizes_compatibility(ms, Hs) = all(size_compatibility(m, H) for (m, H) in zi
     Hs = [H1, H2, H3]
     ms = m1, m2, m3 = [rand(size(H)...) for H in Hs]
     vs = v1, v2, v3 = [rand(size(H, 1)) for H in Hs]
-    @test kron_sizes_compatibility(ms, Hs)
-    @test kron_sizes_compatibility([I, I, m3], Hs)
-    @test !kron_sizes_compatibility(ms, reverse(Hs))
-    @test !kron_sizes_compatibility([I, I, m2], Hs)
-    @test kron_sizes_compatibility(vs, Hs)
-    @test !kron_sizes_compatibility(vs, reverse(Hs))
+    @test kron_sizes_compatible(ms, Hs)
+    @test kron_sizes_compatible([I, I, m3], Hs)
+    @test !kron_sizes_compatible(ms, reverse(Hs))
+    @test !kron_sizes_compatible([I, I, m2], Hs)
+    @test kron_sizes_compatible(vs, Hs)
+    @test !kron_sizes_compatible(vs, reverse(Hs))
     @test_throws ArgumentError fermionic_kron(ms, reverse(Hs))
     H12 = tensor_product(H1, H2)
     m_too_large = rand(size(H12, 1) + 1, size(H12, 2) + 1)
@@ -92,7 +92,7 @@ end
 Compute the fermionic tensor product of matrices or vectors in `ms` with respect to the spaces `Hs`, respectively. Return a matrix in the space `H`, which defaults to the tensor_product product of `Hs`.
 """
 function fermionic_kron(ms, Hs, H::AbstractHilbertSpace=tensor_product(Hs); phase_factors=true)
-    kron_sizes_compatibility(ms, Hs) || throw(ArgumentError("The sizes of `ms` must match the sizes of `Hs`"))
+    kron_sizes_compatible(ms, Hs) || throw(ArgumentError("The sizes of `ms` must match the sizes of `Hs`"))
     N = ndims(first(ms))
     mout = allocate_tensor_product_result(ms, Hs)
     extend_state = FockMapper(Hs, H)
@@ -490,7 +490,7 @@ end
 Compute the partial trace of a matrix `m`, leaving the subsystem defined by the basis `Hsub`.
 """
 function partial_trace(m::AbstractMatrix{T}, H::AbstractHilbertSpace, Hsub::AbstractHilbertSpace; phase_factors=true, complement=simple_complementary_subsystem(H, Hsub)) where {T}
-    size_compatibility(m, H) || throw(ArgumentError("The size of `m` must match the size of `H`"))
+    size_compatible(m, H) || throw(ArgumentError("The size of `m` must match the size of `H`"))
     mout = zeros(T, size(Hsub))
     partial_trace!(mout, m, H, Hsub, phase_factors, complement)
 end


### PR DESCRIPTION
Previously, calling fermionic_kron and partial_trace with matrices larger than their corresponding Hilbert spaces would silently go through. This PR throws an error in those cases.