### PR TITLE
Remove size(::HilbertSpace) in favor of dim(::HilbertSpace)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FermionicHilbertSpaces"
 uuid = "82e5dd95-83c3-46b2-a303-acc930c81756"
 authors = ["Viktor Svensson", "William Samuelson"]
-version = "0.7.1"
+version = "0.8.0"
 
 [deps]
 BitPermutations = "81206824-6155-40a8-95f7-18696067be4d"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -10,7 +10,8 @@ H = hilbert_space(1:N, ParityConservation())
 @fermions f
 op = sum(rand() * f[n]' * f[n] for n in 1:N) + sum(1im * f[n]' * f[n+1] + hc for n in 1:N-1)
 Hsub = hilbert_space(1:div(N, 4), ParityConservation())
-m = sprand(ComplexF64, size(H)..., 1 / 2^N)
+d = dimension(H)
+m = sprand(ComplexF64, d, d, 1 / 2^N)
 
 SUITE["hilbert_space"] = @benchmarkable hilbert_space($(1:N), $ParityConservation())
 SUITE["symbolic_sum"] = @benchmarkable sum(f[n]' * f[n] + hc for n in 1:100)
@@ -29,7 +30,8 @@ Hbdg = bdg_hilbert_space(1:1000)
 SUITE["matrix_representation_bdg"] = @benchmarkable matrix_representation($opsp_bdg, $Hbdg)
 
 SUITE["partial_trace"] = @benchmarkable partial_trace($m, $(H => Hsub))
-msub = rand(ComplexF64, size(Hsub))
+d = dimension(Hsub)
+msub = rand(ComplexF64, d, d)
 SUITE["embed"] = @benchmarkable embed($msub, $(Hsub => H))
 
 # using Symbolics

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -58,7 +58,7 @@ tensor_product((c1, c3), (H1, H2) => H) ≈ c1c3
 Let's partial trace to sites 1 and 3. Let's get a Hilbert space for those sites by using the function `subregion`, and then we can partial trace to that space with `partial_trace`.
 ```@example intro
 Hsub = subregion([1,3], H)
-size(Hsub, 1) / size(H, 1) * partial_trace(c1c3, H => Hsub) ≈ matrix_representation(c[1] * c[3], Hsub)
+dim(Hsub) / dim(H) * partial_trace(c1c3, H => Hsub) ≈ matrix_representation(c[1] * c[3], Hsub)
 ```
 
 ## Conserved quantum numbers

--- a/docs/src/misc.md
+++ b/docs/src/misc.md
@@ -31,7 +31,7 @@ H = tensor_product(Hs)
 ```
 
 ```@example double_occupation
-size(H,1) == 3^N
+dim(H) == 3^N
 ```
 
 Can also take product of symmetries

--- a/examples/kitaev_chain.jl
+++ b/examples/kitaev_chain.jl
@@ -56,7 +56,7 @@ first(oddeigs[1]) - first(eveneigs[1])
 # Now, we construct the ground state Majoranas.
 # First, we need to embed the lowest energy odd and even states into the full Hilbert space.
 function extend(v, p)
-    mapreduce(H -> H == first(p) ? v : zeros(size(H, 1)), vcat, last(p))
+    mapreduce(H -> H == first(p) ? v : zeros(dim(H)), vcat, last(p))
 end
 
 Hsum = (Hodd, Heven)

--- a/examples/number_conservation.jl
+++ b/examples/number_conservation.jl
@@ -28,7 +28,7 @@ Base.size(m::Rank1Matrix) = (length(m.vec), length(m.vec))
 rho = Rank1Matrix(vecs[1]);
 subrho = partial_trace(rho, H => Hsub)
 sum(v -> -v * log(abs(v)), eigvals(subrho))
-size(Hsub, 1) / size(H, 1) * partial_trace(c1c3, H => Hsub) ≈ matrix_representation(c[1] * c[3], Hsub)
+dim(Hsub) / dim(H) * partial_trace(c1c3, H => Hsub) ≈ matrix_representation(c[1] * c[3], Hsub)
 
 H = hilbert_space(labels, NumberConservation([2, 4]))
 matrix_representation(ham, H)

--- a/src/FermionicHilbertSpaces.jl
+++ b/src/FermionicHilbertSpaces.jl
@@ -12,7 +12,7 @@ using NonCommutativeProducts
 import NonCommutativeProducts: @nc_eager, Swap, NCAdd, NCMul, NCterms, AddTerms, add!!
 
 
-export FockNumber, JordanWignerOrdering, hc, basisstates
+export FockNumber, JordanWignerOrdering, hc, basisstates, dim
 export FockHilbertSpace, SymmetricFockHilbertSpace, SimpleFockHilbertSpace, hilbert_space, subregion
 export parityoperator, numberoperator, fermions, majoranas, matrix_representation
 

--- a/src/bdg.jl
+++ b/src/bdg.jl
@@ -32,8 +32,7 @@ struct BdGHilbertSpace{H} <: AbstractFockHilbertSpace
     end
 end
 bdg_hilbert_space(labels) = BdGHilbertSpace(labels)
-Base.size(h::BdGHilbertSpace) = size(h.parent)
-Base.size(h::BdGHilbertSpace, dim) = size(h.parent, dim)
+dim(h::BdGHilbertSpace) = dim(h.parent)
 mode_ordering(h::BdGHilbertSpace) = mode_ordering(h.parent)
 modes(H::BdGHilbertSpace) = modes(H.parent)
 Base.keys(h::BdGHilbertSpace) = keys(h.parent)

--- a/src/fixednumberfock.jl
+++ b/src/fixednumberfock.jl
@@ -173,7 +173,7 @@ struct SingleParticleHilbertSpace{H} <: AbstractFockHilbertSpace
         return new{typeof(H)}(H)
     end
 end
-dim(h::SingleParticleHilbertSpace) = size(h.parent)
+dim(h::SingleParticleHilbertSpace) = dim(h.parent)
 Base.parent(h::SingleParticleHilbertSpace) = h.parent
 Base.keys(h::SingleParticleHilbertSpace) = keys(h.parent)
 mode_ordering(h::SingleParticleHilbertSpace) = mode_ordering(h.parent)

--- a/src/fixednumberfock.jl
+++ b/src/fixednumberfock.jl
@@ -173,8 +173,7 @@ struct SingleParticleHilbertSpace{H} <: AbstractFockHilbertSpace
         return new{typeof(H)}(H)
     end
 end
-Base.size(h::SingleParticleHilbertSpace) = size(h.parent)
-Base.size(h::SingleParticleHilbertSpace, dim) = size(h.parent, dim)
+dim(h::SingleParticleHilbertSpace) = size(h.parent)
 Base.parent(h::SingleParticleHilbertSpace) = h.parent
 Base.keys(h::SingleParticleHilbertSpace) = keys(h.parent)
 mode_ordering(h::SingleParticleHilbertSpace) = mode_ordering(h.parent)

--- a/src/hilbert_space.jl
+++ b/src/hilbert_space.jl
@@ -1,13 +1,13 @@
 function Base.show(io::IO, H::Htype) where Htype<:AbstractFockHilbertSpace
-    n, m = size(H)
-    println(io, "$(n)⨯$m $(Htype.name.name):")
-    print(io, "modes: ")
+    d = dim(H)
+    N = length(keys(H))
+    println(io, "$(d)-dimensional $(Htype.name.name):")
+    print(io, "$N fermions: ")
     print(IOContext(io, :compact => true), modes(H))
 end
 Base.show(io::IO, ::MIME"text/plain", H::AbstractHilbertSpace) = show(io, H)
 
-Base.size(H::AbstractHilbertSpace) = (length(basisstates(H)), length(basisstates(H)))
-Base.size(H::AbstractHilbertSpace, i) = i == 1 || i == 2 ? length(basisstates(H)) : throw(BoundsError(H, (i,)))
+dim(H::AbstractHilbertSpace) = length(basisstates(H))
 isorderedpartition(Hs, H::AbstractFockHilbertSpace) = isorderedpartition(map(modes, Hs), H.jw)
 isorderedsubsystem(Hsub::AbstractFockHilbertSpace, H::AbstractFockHilbertSpace) = isorderedsubsystem(Hsub.jw, H.jw)
 isorderedsubsystem(Hsub::AbstractFockHilbertSpace, jw::JordanWignerOrdering) = isorderedsubsystem(Hsub.jw, jw)
@@ -112,9 +112,10 @@ function SymmetricFockHilbertSpace(jw::JordanWignerOrdering, qn::AbstractSymmetr
 end
 
 function Base.show(io::IO, H::SymmetricFockHilbertSpace)
-    n, m = size(H)
-    println(io, "$(n)⨯$m SymmetricFockHilbertSpace:")
-    print(io, "modes: ")
+    d = dim(H)
+    N = length(keys(H))
+    println(io, "$(d)-dimensional SymmetricFockHilbertSpace:")
+    print(io, "$N fermions: ")
     println(IOContext(io, :compact => true), modes(H))
     show(io, H.symmetry)
 end

--- a/src/majorana_hilbert_space.jl
+++ b/src/majorana_hilbert_space.jl
@@ -2,7 +2,7 @@ struct MajoranaHilbertSpace{L,H} <: AbstractFockHilbertSpace
     majoranaindices::L
     parent::H
 end
-Base.size(H::MajoranaHilbertSpace) = size(H.parent)
+dim(H::MajoranaHilbertSpace) = dim(H.parent)
 mode_ordering(H::MajoranaHilbertSpace) = mode_ordering(H.parent)
 modes(H::MajoranaHilbertSpace) = modes(H.parent)
 Base.:(==)(H1::MajoranaHilbertSpace, H2::MajoranaHilbertSpace) = H1.majoranaindices == H2.majoranaindices && H1.parent == H2.parent
@@ -106,7 +106,7 @@ end
     Hsub = subregion(1:2, H)
     Hf = H.parent
     Hfsub = subregion([(1, 2)], Hf)
-    m = rand(size(H)...)
+    m = rand(dim(H), dim(H))
     @test partial_trace(m, H => Hsub) == partial_trace(m, Hf => Hfsub)
     Hsub2 = subregion(3:4, H)
     Hfsub2 = subregion([(3, 4)], Hf)
@@ -114,7 +114,7 @@ end
     Hprod = tensor_product(Hsub, Hsub2)
     @test parent(Hprod) == tensor_product(Hfsub, Hfsub2)
 
-    m1 = rand(size(Hsub)...)
-    m2 = rand(size(Hsub2)...)
+    m1 = rand(dim(Hsub), dim(Hsub))
+    m2 = rand(dim(Hsub2), dim(Hsub2))
     @test tensor_product((m1, m2), (Hsub, Hsub2), Hprod) == tensor_product((m1, m2), (Hfsub, Hfsub2) => parent(Hprod))
 end

--- a/src/qubit.jl
+++ b/src/qubit.jl
@@ -56,8 +56,10 @@ qubit_operator(c, ::QubitOp{:H}) = 1 / sqrt(2) * (qubit_operator(c, QubitOp{:Z}(
 
     ## Test that partial trace is the adjoint of embed
     using LinearMaps
-    ptmap = LinearMap(rhovec -> vec(partial_trace(reshape(rhovec, size(H)), H, H1; phase_factors=false)), prod(size(H1)), prod(size(H)))
-    embeddingmap = LinearMap(rhovec -> vec(embed(reshape(rhovec, size(H1)), H1, H; phase_factors=false)), prod(size(H)), prod(size(H1)))
+    d1 = dim(H1)
+    d = dim(H)
+    ptmap = LinearMap(rhovec -> vec(partial_trace(reshape(rhovec, (d, d)), H, H1; phase_factors=false)), d1^2, d^2)
+    embeddingmap = LinearMap(rhovec -> vec(embed(reshape(rhovec, (d1, d1)), H1, H; phase_factors=false)), d^2, d1^2)
     @test Matrix(ptmap) ≈ Matrix(embeddingmap)'
 
 end

--- a/src/symbolics/muladd.jl
+++ b/src/symbolics/muladd.jl
@@ -6,7 +6,7 @@ Base.valtype(::Type{NCMul{C,S,F}}) where {C,S<:AbstractFermionSym,F} = promote_t
 
 ## Instantiating sparse matrices
 matrix_representation(op, H::AbstractFockHilbertSpace) = matrix_representation(op, mode_ordering(H), basisstates(H), Dict(Iterators.map(reverse, enumerate(basisstates(H)))))
-matrix_representation(op::Number, H::AbstractFockHilbertSpace) = op * I(size(H, 1))
+matrix_representation(op::Number, H::AbstractFockHilbertSpace) = op * I(dim(H))
 
 function matrix_representation(op::Union{<:NCMul,<:AbstractFermionSym}, labels, states, fock_to_ind)
     outinds = Int[]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,8 +37,10 @@ using TestItemRunner
     @test t1 == FockNumber.(t2)
 
     using LinearMaps
-    ptmap = LinearMap(rhovec -> vec(partial_trace(reshape(rhovec, size(H)), H, H1)), prod(size(H1)), prod(size(H)))
-    embeddingmap = LinearMap(rhovec -> vec(embed(reshape(rhovec, size(H1)), H1, H)), prod(size(H)), prod(size(H1)))
+    d = dim(H)
+    d1 = dim(H1)
+    ptmap = LinearMap(rhovec -> vec(partial_trace(reshape(rhovec, (d, d)), H, H1)), d1^2, d^2)
+    embeddingmap = LinearMap(rhovec -> vec(embed(reshape(rhovec, (d1, d1)), H1, H)), d^2, d1^2)
     @test Matrix(ptmap) ≈ Matrix(embeddingmap)'
 
     H = hilbert_space(Base.product(1:2, (:a, :b)))
@@ -71,12 +73,14 @@ end
 
 @testitem "Fermionic partial trace" begin
     using LinearAlgebra, LinearMaps
-
+    
     function test_adjoint(Hsub, H)
         pt = partial_trace(H => Hsub)
         emb = embed(Hsub => H)
-        ptmap = LinearMap(rhovec -> vec(pt(reshape(rhovec, size(H)))), prod(size(Hsub)), prod(size(H)))
-        embeddingmap = LinearMap(rhovec -> vec(emb(reshape(rhovec, size(Hsub)))), prod(size(H)), prod(size(Hsub)))
+        dsub = dim(Hsub)
+        d = dim(H)
+        ptmap = LinearMap(rhovec -> vec(pt(reshape(rhovec, (d, d)))), dsub^2, d^2)
+        embeddingmap = LinearMap(rhovec -> vec(emb(reshape(rhovec, (dsub, dsub)))), d^2, dsub^2)
         @test Matrix(ptmap) ≈ Matrix(embeddingmap)'
     end
     qns = [NoSymmetry(), ParityConservation(), NumberConservation()]


### PR DESCRIPTION
Previously, `size` of hilbert space would return (d, d) where d is the dimension of the hilbert space. This is removed. Use `dim(::HilbertSpace)`.