### PR TITLE
Symbolic partial trace

### DIFF
--- a/src/majorana_hilbert_space.jl
+++ b/src/majorana_hilbert_space.jl
@@ -48,13 +48,16 @@ end
 function partial_trace(m::NCAdd{C,NCMul{C2,S,F}}, H::MajoranaHilbertSpace, Hsub::MajoranaHilbertSpace) where {C,C2,S<:AbstractMajoranaSym,F}
     return sum(partial_trace(term, H, Hsub) for term in NCterms(m))
 end
+function partial_trace(m::NCAdd{C,NCMul{C2,S,F}}, Hs::Pair{<:MajoranaHilbertSpace,<:MajoranaHilbertSpace}) where {C,C2,S<:AbstractMajoranaSym,F}
+    return partial_trace(m, Hs...)
+end
 
 @testitem "Partial trace of symbolic Majoranas" begin
     @majoranas y
     H = majorana_hilbert_space(1:6)
-    Hsub = subregion(5:6, H)
-    op = 3y[1] + 2y[5] + 3y[2]*y[5] - y[5]*y[6]
-    @test partial_trace(op, H, Hsub) == 8y[5] - 4y[5]*y[6]
+    Hsub = subregion(3:4, H)
+    op = 3y[1] + 2y[3] + 3y[4]*y[1] + y[3]*y[4]
+    @test matrix_representation(partial_trace(op, H => Hsub), Hsub) == partial_trace(matrix_representation(op, H), H => Hsub)
 end
 
 function simple_complementary_subsystem(H::MajoranaHilbertSpace, Hsub::MajoranaHilbertSpace)

--- a/src/symbolics/muladd.jl
+++ b/src/symbolics/muladd.jl
@@ -173,3 +173,10 @@ end
     end
     @test a == 1.0 * f[2] * f[1] + 1 + f[1]
 end
+
+function partial_trace(m::NCMul{C, <:MajoranaSym}, H::MajoranaHilbertSpace, Hsub::MajoranaHilbertSpace) where C
+    sub_modes = Set(Iterators.flatten(modes(Hsub)))
+    # go through factors
+    # if any label is not in sub_modes, return 0
+    # otherwise, return m but normalized
+end

--- a/src/symbolics/muladd.jl
+++ b/src/symbolics/muladd.jl
@@ -173,10 +173,3 @@ end
     end
     @test a == 1.0 * f[2] * f[1] + 1 + f[1]
 end
-
-function partial_trace(m::NCMul{C, <:MajoranaSym}, H::MajoranaHilbertSpace, Hsub::MajoranaHilbertSpace) where C
-    sub_modes = Set(Iterators.flatten(modes(Hsub)))
-    # go through factors
-    # if any label is not in sub_modes, return 0
-    # otherwise, return m but normalized
-end


### PR DESCRIPTION
Tried implementing a symbolic version of partial trace for Majoranas. 

- A bit unsure what to return when a term extends outside the region. I just did `0 * m` for now.
- I decided to put it in `majorana_hilbert_space.jl`, since I needed both symbolics and the `MajoranaHilbertSpace`.
- Anything else I haven't thought about?